### PR TITLE
Troubleshoot nukes-v2.js build failure

### DIFF
--- a/nukes-v2.js
+++ b/nukes-v2.js
@@ -583,7 +583,8 @@ let pendingBody = null;
       const id = videoIdFromUrl(singles[0]);
       e.target.loadVideoById(id);
     }
-function onMusicState(e){
+  }
+  function onMusicState(e){
   // Track title only; do not touch volume here to avoid mid-song dips
   if (e?.data === (window.YT?.PlayerState?.PLAYING)){
     try {


### PR DESCRIPTION
Add missing closing brace in `nukes-v2.js` to fix Vite build parse error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0e4c7b8-d79f-41c8-9dfd-b08f761c1efc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0e4c7b8-d79f-41c8-9dfd-b08f761c1efc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

