### PR TITLE
refactor: extract reusable glass panel component

### DIFF
--- a/perday-music/src/components/FocusRunning.tsx
+++ b/perday-music/src/components/FocusRunning.tsx
@@ -5,6 +5,7 @@ import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { Pause, Target, Clock, MessageSquare, Square } from 'lucide-react';
 import MultiplierBar from './MultiplierBar';
+import GlassPanel from './common/GlassPanel';
 
 export default function FocusRunning() {
   const { session, dispatch } = useAppStore();
@@ -63,7 +64,7 @@ export default function FocusRunning() {
 
   return (
     <div className="min-h-screen bg-black flex items-center justify-center p-8">
-      <div className="bg-gradient-to-br from-magenta-900/20 via-cyan-900/20 to-purple-900/20 backdrop-blur-xl ring-1 ring-cyan-400/30 rounded-2xl p-8 max-w-2xl w-full">
+      <GlassPanel className="bg-gradient-to-br from-magenta-900/20 via-cyan-900/20 to-purple-900/20 p-8 max-w-2xl w-full">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-synth-white mb-2">Focus Session</h1>
           <p className="text-synth-icy/70">Stay focused, stay productive</p>
@@ -185,7 +186,7 @@ export default function FocusRunning() {
             End Session
           </Button>
         </div>
-      </div>
+      </GlassPanel>
     </div>
   );
 }

--- a/perday-music/src/components/FocusSetup.tsx
+++ b/perday-music/src/components/FocusSetup.tsx
@@ -5,6 +5,7 @@ import { Button } from './ui/button';
 import { Target, Clock, ArrowLeft, ArrowRight, Play } from 'lucide-react';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
+import GlassPanel from './common/GlassPanel';
 
 export default function FocusSetup() {
   const { session, dispatch } = useAppStore();
@@ -42,7 +43,7 @@ export default function FocusSetup() {
 
   return (
     <div className="min-h-screen bg-black flex items-center justify-center p-8">
-      <div className="bg-gradient-to-br from-magenta-900/20 via-cyan-900/20 to-purple-900/20 backdrop-blur-xl ring-1 ring-cyan-400/30 rounded-2xl p-8 max-w-2xl w-full">
+      <GlassPanel className="bg-gradient-to-br from-magenta-900/20 via-cyan-900/20 to-purple-900/20 p-8 max-w-2xl w-full">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-synth-white mb-2">Focus Setup</h1>
           <p className="text-synth-icy/70">
@@ -142,7 +143,7 @@ export default function FocusSetup() {
             </div>
           </div>
         )}
-      </div>
+      </GlassPanel>
     </div>
   );
 }

--- a/perday-music/src/components/LiquidGlassButton.module.css
+++ b/perday-music/src/components/LiquidGlassButton.module.css
@@ -1,0 +1,72 @@
+.liquidGlassButton {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.3),
+    inset 0 2px 4px rgba(0, 0, 0, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.2),
+    0 0 20px rgba(255, 255, 255, 0.1);
+  transition: all 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+  position: relative;
+  transform-origin: center center;
+}
+
+.liquidGlassButton::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.2) 0%,
+    rgba(255, 255, 255, 0.05) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+
+.liquidGlassButton:hover {
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: translateY(-2px);
+  box-shadow:
+    0 16px 50px rgba(0, 0, 0, 0.4),
+    inset 0 2px 4px rgba(0, 0, 0, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.2),
+    0 0 25px rgba(255, 255, 255, 0.15);
+}
+
+.liquidGlassButton:active {
+  transform: translateY(1px) scale(0.96);
+  border-color: rgba(255, 255, 255, 0.5);
+  transition: all 0.1s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@keyframes liquidRipple {
+  0% {
+    transform: scale(0);
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(4);
+    opacity: 0;
+  }
+}
+
+.ripple {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.4);
+  transform: translate(-50%, -50%);
+  animation: liquidRipple 0.6s ease-out forwards;
+}

--- a/perday-music/src/components/LiquidGlassButton.tsx
+++ b/perday-music/src/components/LiquidGlassButton.tsx
@@ -1,5 +1,7 @@
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback } from "react";
 // gsap import removed as it's not used
+import styles from "./LiquidGlassButton.module.css";
+import { cn } from "../lib/utils";
 
 interface LiquidGlassButtonProps {
   children: React.ReactNode;
@@ -109,106 +111,26 @@ export default function LiquidGlassButton({
       ref={buttonRef}
       onClick={handleClick}
       disabled={disabled}
-      className={`
-        liquid-glass-button
-        ${getVariantStyles()}
-        ${getSizeStyles()}
-        ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
-        ${isPressed ? 'scale-95' : ''}
-        transition-all duration-150 ease-out
-        font-medium
-        select-none
-        backdrop-blur-3xl
-        relative
-        overflow-hidden
-        ${className}
-      `}
+      className={cn(
+        styles.liquidGlassButton,
+        getVariantStyles(),
+        getSizeStyles(),
+        disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
+        isPressed && "scale-95",
+        "transition-all duration-150 ease-out font-medium select-none relative overflow-hidden",
+        className
+      )}
       style={style}
     >
       {ripples.map((ripple) => (
         <div
           key={ripple.id}
-          className="absolute pointer-events-none"
-          style={{
-            left: ripple.x,
-            top: ripple.y,
-            width: '4px',
-            height: '4px',
-            borderRadius: '50%',
-            background: 'rgba(255, 255, 255, 0.4)',
-            transform: 'translate(-50%, -50%)',
-            animation: 'liquidRipple 0.6s ease-out forwards',
-          }}
+          className={cn("absolute pointer-events-none", styles.ripple)}
+          style={{ left: ripple.x, top: ripple.y }}
         />
       ))}
 
       {buttonContent}
-
-      <style>{`
-        .liquid-glass-button {
-          background: rgba(255, 255, 255, 0.1);
-          backdrop-filter: blur(20px);
-          border: 1px solid rgba(255, 255, 255, 0.2);
-          box-shadow: 
-            0 12px 40px rgba(0, 0, 0, 0.3),
-            inset 0 2px 4px rgba(0, 0, 0, 0.2), 
-            inset 0 1px 0 rgba(255, 255, 255, 0.4),
-            inset 0 -1px 0 rgba(0, 0, 0, 0.2), 
-            0 0 20px rgba(255, 255, 255, 0.1);
-          transition: all 0.3s cubic-bezier(0.23, 1, 0.32, 1);
-          position: relative;
-          transform-origin: center center;
-        }
-
-        .liquid-glass-button::before {
-          content: "";
-          position: absolute;
-          top: 0;
-          left: 0;
-          right: 0;
-          bottom: 0;
-          border-radius: inherit;
-          background: linear-gradient(
-            145deg,
-            rgba(255, 255, 255, 0.2) 0%,
-            rgba(255, 255, 255, 0.05) 50%,
-            rgba(255, 255, 255, 0) 100%
-          );
-          pointer-events: none;
-          z-index: 1;
-        }
-
-        .liquid-glass-button:hover {
-          border-color: rgba(255, 255, 255, 0.4);
-          transform: translateY(-2px);
-          box-shadow: 
-            0 16px 50px rgba(0, 0, 0, 0.4),
-            inset 0 2px 4px rgba(0, 0, 0, 0.2), 
-            inset 0 1px 0 rgba(255, 255, 255, 0.4),
-            inset 0 -1px 0 rgba(0, 0, 0, 0.2), 
-            0 0 25px rgba(255, 255, 255, 0.15);
-        }
-
-        .liquid-glass-button:active {
-          transform: translateY(1px) scale(0.96);
-          border-color: rgba(255, 255, 255, 0.5);
-          transition: all 0.1s cubic-bezier(0.23, 1, 0.32, 1);
-        }
-
-        @keyframes liquidRipple {
-          0% {
-            transform: scale(0);
-            opacity: 1;
-          }
-          50% {
-            opacity: 0.6;
-          }
-          100% {
-            transform: scale(4);
-            opacity: 0;
-          }
-        }
-      `}</style>
     </button>
   );
 }

--- a/perday-music/src/components/LockInMenu.tsx
+++ b/perday-music/src/components/LockInMenu.tsx
@@ -2,6 +2,7 @@ import { useAppStore } from '../store/store';
 import { FlowState } from '../types';
 import { Button } from './ui/button';
 import { Target, Clock, ArrowLeft, Music, Zap } from 'lucide-react';
+import GlassPanel from './common/GlassPanel';
 
 export default function LockInMenu() {
   const { session, dispatch } = useAppStore();
@@ -28,7 +29,7 @@ export default function LockInMenu() {
 
   return (
     <div className="min-h-screen bg-black flex items-center justify-center p-8">
-      <div className="bg-gradient-to-br from-magenta-900/20 via-cyan-900/20 to-purple-900/20 backdrop-blur-xl ring-1 ring-cyan-400/30 rounded-2xl p-8 max-w-2xl w-full">
+      <GlassPanel className="bg-gradient-to-br from-magenta-900/20 via-cyan-900/20 to-purple-900/20 p-8 max-w-2xl w-full">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-synth-white mb-2">Lock-In Your Lane</h1>
           <p className="text-synth-icy/70">
@@ -69,7 +70,7 @@ export default function LockInMenu() {
             Back to Pre-Start
           </Button>
         </div>
-      </div>
+      </GlassPanel>
     </div>
   );
 }

--- a/perday-music/src/components/StartHero.tsx
+++ b/perday-music/src/components/StartHero.tsx
@@ -14,6 +14,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
 import UserQuestionnaire from "./UserQuestionnaire";
 import { Settings } from "lucide-react";
 import { toast } from "sonner";
+import GlassPanel from "./common/GlassPanel";
 
 /** Overlay FSM so only ONE overlay can ever mount at a time */
 type Overlay = "none" | "questionnaire" | "setup";
@@ -111,7 +112,7 @@ export default function StartHero({ fadeOutRef }: StartHeroProps) {
           </div>
 
           {/* Main card */}
-          <div className="relative z-10 rounded-2xl bg-gradient-to-br from-magenta-900/20 via-cyan-900/20 to-purple-900/20 backdrop-blur-xl ring-1 ring-cyan-400/30 p-8 max-w-md w-full text-center shadow-2xl">
+          <GlassPanel className="relative z-10 bg-gradient-to-br from-magenta-900/20 via-cyan-900/20 to-purple-900/20 p-8 max-w-md w-full text-center shadow-2xl">
             <div className="text-xl font-bold text-white mb-2">
               {`Welcome back, ${userName}!`}
             </div>
@@ -159,7 +160,7 @@ export default function StartHero({ fadeOutRef }: StartHeroProps) {
                 ✅ Ready locked. Multiplier boosted.
               </div>
             )}
-          </div>
+          </GlassPanel>
 
           {/* Overlays (mutually exclusive) */}
           {/* Vault overlay removed - no longer needed */}
@@ -196,10 +197,10 @@ export default function StartHero({ fadeOutRef }: StartHeroProps) {
           <div className="absolute inset-0 -z-10 pointer-events-none opacity-20" aria-hidden="true">
             <AtomOrbit />
           </div>
-          <div className="mx-auto max-w-md rounded-2xl bg-black/40 backdrop-blur-xl ring-1 ring-cyan-300/30 p-8 text-center">
+          <GlassPanel className="mx-auto max-w-md bg-black/40 ring-cyan-300/30 p-8 text-center">
             <h2 className="text-2xl font-bold text-white mb-6">Lock-In your lane</h2>
             <p className="text-cyan-200/80">Cook. Wrap. Log. & Stack MORE wins!</p>
-          </div>
+          </GlassPanel>
         </div>
       );
 

--- a/perday-music/src/components/common/GlassPanel.tsx
+++ b/perday-music/src/components/common/GlassPanel.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { cn } from "../../lib/utils";
+
+export interface GlassPanelProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export default function GlassPanel({ children, className, ...props }: GlassPanelProps) {
+  return (
+    <div
+      className={cn(
+        "bg-black/20 backdrop-blur-xl ring-1 ring-cyan-400/30 rounded-2xl",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `GlassPanel` component encapsulating frosted glass classes
- refactor StartHero, FocusSetup, LockInMenu and FocusRunning to use new component
- extract LiquidGlassButton styles into CSS module with ripple animation

## Testing
- `npm test` *(fails: Invalid Chai property: toBeInTheDocument; Cannot set properties of null; HTMLCanvasElement.prototype.getContext not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68ace834ddcc8331a5ab23929a4550dc